### PR TITLE
Added possibility to override default parameter values using environment variable

### DIFF
--- a/Common.h
+++ b/Common.h
@@ -256,4 +256,5 @@ extern NSString * const ScriptExecDefaultsKey_ShowDetails;
 // Prototypes
 extern BOOL UTTypeIsValid(NSString *inUTI);
 extern BOOL BundleIdentifierIsValid(NSString *bundleIdentifier);
-
+extern NSString *GetCustomEnvironmentVariable(const char *envVarName);
+extern NSString *GetCustomEnvironmentVariableOrDefault(const char *envVarName, const NSString *defaultValue);

--- a/Common.m
+++ b/Common.m
@@ -28,6 +28,7 @@
     POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <stdio.h>
 #import <Foundation/Foundation.h>
 #import "Common.h"
 
@@ -116,4 +117,18 @@ BOOL BundleIdentifierIsValid(NSString *bundleIdentifier) {
     BOOL validUTI = UTTypeIsValid(bundleIdentifier);
     BOOL hasThreeComponents = ([[bundleIdentifier componentsSeparatedByString:@"."] count] >= 3);
     return (validUTI && hasThreeComponents);
+}
+
+NSString *GetCustomEnvironmentVariable(const char *envVarName) {
+    char *envVarPtr = getenv(envVarName);
+    if (envVarPtr) {
+        NSString *envVarValue = [NSString stringWithCString:envVarPtr encoding:NSUTF8StringEncoding];
+        return envVarValue;
+    }
+    return nil;
+}
+
+NSString *GetCustomEnvironmentVariableOrDefault(const char *envVarName, const NSString *defaultValue) {
+    NSString *envVarValue = GetCustomEnvironmentVariable(envVarName);
+    return envVarValue ? envVarValue : defaultValue;
 }

--- a/Shared/PlatypusAppSpec.m
+++ b/Shared/PlatypusAppSpec.m
@@ -134,8 +134,8 @@
 - (void)setDefaults {
     self[AppSpecKey_Creator] = PROGRAM_CREATOR_STAMP;
     
-    self[AppSpecKey_ExecutablePath] = CMDLINE_SCRIPT_EXEC_PATH;
-    self[AppSpecKey_NibPath] = CMDLINE_NIB_PATH;
+    self[AppSpecKey_ExecutablePath] = GetCustomEnvironmentVariableOrDefault("CMDLINE_SCRIPT_EXEC_PATH", CMDLINE_SCRIPT_EXEC_PATH);
+    self[AppSpecKey_NibPath] = GetCustomEnvironmentVariableOrDefault("CMDLINE_NIB_PATH", CMDLINE_NIB_PATH);
     self[AppSpecKey_DestinationPath] = DEFAULT_DESTINATION_PATH;
     self[AppSpecKey_Overwrite] = @NO;
     self[AppSpecKey_SymlinkFiles] = @NO;
@@ -144,7 +144,7 @@
     self[AppSpecKey_Name] = DEFAULT_APP_NAME;
     self[AppSpecKey_ScriptPath] = @"";
     self[AppSpecKey_InterfaceType] = DEFAULT_INTERFACE_TYPE_STRING;
-    self[AppSpecKey_IconPath] = CMDLINE_ICON_PATH;
+    self[AppSpecKey_IconPath] = GetCustomEnvironmentVariableOrDefault("CMDLINE_ICON_PATH", CMDLINE_ICON_PATH);
     
     self[AppSpecKey_InterpreterPath] = DEFAULT_INTERPRETER_PATH;
     self[AppSpecKey_InterpreterArgs] = @[];


### PR DESCRIPTION
This feature is needed in environments where user cannot install outside user's home directory. This allows to override values of these parameters: CMDLINE_SCRIPT_EXEC_PATH, CMDLINE_NIB_PATH and CMDLINE_ICON_PATH by using equally named environment variables.